### PR TITLE
To make the default port dynamically set to the port found in the tor…

### DIFF
--- a/torchat.py
+++ b/torchat.py
@@ -24,7 +24,7 @@ def read_tor_port():
         return None
     with open(TORRC_PATH, "r") as f:
         for line in f:
-            if line.strip().startswith("SocksPort"):
+            if line.strip().startswith("HiddenServicePort"):
                 match = re.search(r"\b(\d+)\b", line)
                 if match:
                     return match.group(1)


### PR DESCRIPTION
…rc file, we simply need to update the script logic so that:

We read the port from torrc first.

If it's found, we use it as the default port instead of hardcoded 4444.